### PR TITLE
fixed math to map XY to corresponding LED

### DIFF
--- a/firmware/examples/6_Orientation.cpp
+++ b/firmware/examples/6_Orientation.cpp
@@ -20,18 +20,23 @@ void loop(){
     
     // How about in the y direction?
     int yValue = b.readY();
+
+    // If we're close to level, light all LEDs green
+    if(abs(xValue)<2 and abs(yValue)<2) {
+        b.allLedsOn(0,255,0);
+        delay(100);
+        return;
+    }
     
     // Now we'll do some trig to figure out which LED that direction maps to
-    // ... ok, it doesn't work well yet. Need to go back to the napkin.
     float rads = atan2(yValue,xValue);
-    int ledPos = 12 - abs(rads/(M_PI/6) + 6);
+    int ledPos = (int)(12 - (rads/(M_PI/6) - 3)) % 12;
     
+    // Turn all LEDs off before turning one on
+    b.allLedsOff();
     // Now turn that LED on
     b.ledOn(ledPos, 0, 30, 30);
     
     // Wait a mo'
     delay(100);
-    
-    // Turn the LEDs off so they don't all end up on
-    b.ledOff(ledPos);
 }


### PR DESCRIPTION
Hi,

I fixed the math to map the XY values from the accelerometer. It now lights up the correct corresponding LED. If the core+shield is (close to) level alle LEDs are set to green.

This request is part of the OpenGarage Instructables Spark Core Build Night ;-)

Regards,
Christophe VG
