### PR TITLE
Changed to the appropriate deviceID

### DIFF
--- a/controlKnob.html
+++ b/controlKnob.html
@@ -52,7 +52,7 @@
             //Call the Spark.function!
             var sendApiRequest = function (v) {
                 console.log('setting lamp to ' + v);
-                spark.callFunction(devices[9].id, 'controller', v, callback);
+                spark.callFunction(devicesID, 'controller', v, callback);
             };
             var _timer = null,
                 lastValue = 0,


### PR DESCRIPTION
A hardcoded deviceID was used on line 52 which broke the functionality. Since the deviceID is looked for earlier, that one should be used instead.